### PR TITLE
Added primary icon as required in blui hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v8.0.1 (Unreleased)
+
+### Changed
+
+- Updated `blui-primary` selector in `<blui-hero>` component to be required ([#507](https://github.com/etn-ccis/blui-angular-component-library/issues/507)).
+
 ## v8.0.0 (November 21, 2022)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightlayer-ui/angular-components",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Angular components for Brightlayer UI applications",
   "main": "index.js",
   "prettier": "@brightlayer-ui/prettier-config",

--- a/src/docs/md/Hero.md
+++ b/src/docs/md/Hero.md
@@ -49,7 +49,7 @@ The following child elements are projected into `<blui-hero>`:
 | Selector        | Description                                                 | Required | Default |
 | --------------- | ----------------------------------------------------------- | -------- | ------- |
 | (child)         | The `<blui-channel-value>` to display under the primary icon | no       |         |
-| [blui-primary]   | The large icon displayed on the top                         | no       |         |
+| [blui-primary]   | The large icon displayed on the top                         | yes      |         |
 | [blui-secondary] | The icon displayed to the left of the value and units       | no       |         |
 
 </div>

--- a/src/lib/core/hero/hero.component.ts
+++ b/src/lib/core/hero/hero.component.ts
@@ -10,7 +10,7 @@ import {
     ViewChild,
     ViewEncapsulation,
 } from '@angular/core';
-import { requireInput } from '../../utils/utils';
+import { requireContent, requireInput } from '../../utils/utils';
 import { UnitSpaceType } from '../channel-value/channel-value.component';
 /**
  * [Hero Component](https://brightlayer-ui-components.github.io/angular/?path=/info/components-hero--readme)
@@ -82,6 +82,9 @@ export class HeroComponent implements OnChanges, AfterViewInit, AfterContentChec
     }
 
     ngAfterViewInit(): void {
+        const required = { selector: 'primaryContainer', ref: this.primaryContainer };
+        requireContent([required], this);
+
         this.hasMatSvgIcon = Boolean(this.getMatSvgIcon());
         this._ref.detectChanges();
     }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #507 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added blui-primary as required selector in blui-hero
- Updated package version and changelog

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)

**Just For Testing Locally**
If you do not pass 'blui-primary' in `<blui-hero>`:

<img width="1792" alt="Screenshot 2023-01-17 at 12 49 20 PM" src="https://user-images.githubusercontent.com/120575281/212837579-a21f1df8-f2f4-43c5-8dc0-c16851c7cf70.png">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Clone the repo
- cd blui-angular-component-library
- yarn && yarn start
- open console to check there are no warnings related to HeroComponent
- Update example code in editor **src/docs/pages/component-docs/components/hero/examples/value-units.component.ts**
- Remove 'blui-primary' from line 5
- open console to check there are warnings related to HeroComponent

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


