### PR TITLE
484-Drawer footer should preserver its divider when the drawer is col…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -  Fixed Channel value issue with zero value in `<blui-channel-value>` ([#556](https://github.com/etn-ccis/blui-angular-component-library/issues/556)).
 
+### Fixed
+
+-  Fixed Drawer footer should preserve its divider when the drawer collapses in `<blui-drawer-footer>` ([#484](https://github.com/etn-ccis/blui-angular-component-library/issues/484)).
+
 ## v8.0.1 (January 25, 2023)
 
 ### Added

--- a/src/lib/core/drawer/drawer-footer/drawer-footer.component.ts
+++ b/src/lib/core/drawer/drawer-footer/drawer-footer.component.ts
@@ -12,11 +12,11 @@ import { DrawerStateManagerService, StateListener } from '../state-listener.comp
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     template: `
+        <mat-divider *ngIf="divider"></mat-divider>
         <div
             class="blui-drawer-footer-content"
             [style.visibility]="hideContentOnCollapse ? (isOpen() ? 'visible' : 'hidden') : 'visible'"
         >
-            <mat-divider *ngIf="divider"></mat-divider>
             <ng-content></ng-content>
         </div>
     `,


### PR DESCRIPTION
…lapses issue is fixed

<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #484  .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
-  Moved the <mat-divider> tag outside of the <blui-drawer-footer-content> tag to resolved this issue
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
-
![image](https://user-images.githubusercontent.com/13012853/223152760-c6c28fb7-6de6-420a-a206-73e4f923fe5a.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
-  yarn test

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


