### PR TITLE
Bug/491 herobanner divider not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -  Fixed Channel value issue with zero value in `<blui-channel-value>` ([#556](https://github.com/etn-ccis/blui-angular-component-library/issues/556)).
 
+### Fixed
+
+-  Fixed Divider effect not working in `<blui-hero-banner>` ([#491](https://github.com/etn-ccis/blui-angular-component-library/issues/491)).
+
 ## v8.0.1 (January 25, 2023)
 
 ### Added

--- a/src/lib/core/hero/hero-banner.component.scss
+++ b/src/lib/core/hero/hero-banner.component.scss
@@ -1,5 +1,6 @@
 .blui-hero-banner {
     display: flex;
+    flex-direction: column;
 }
 
 .blui-hero-banner-content {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #491 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
-  Modify the .blui-hero-banner SCSS class to make divider visibility in the <blui-hero-banner> tag
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
-
![image](https://user-images.githubusercontent.com/13012853/224012188-e19ac9e7-d1e4-41b9-9477-4bd3d4dd7365.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
-  yarn test

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


