### PR TITLE
418 chevron and right component use at same time in info list item is…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -  Fixed Channel value issue with zero value in `<blui-channel-value>` ([#556](https://github.com/etn-ccis/blui-angular-component-library/issues/556)).
 
+### Fixed
+
+-  Fixed Ability to use chevron and right component prop on the Info List Item at the same time in `<blui-info-list-item>` ([#418](https://github.com/etn-ccis/blui-angular-component-library/issues/418)).
+
 ## v8.0.1 (January 25, 2023)
 
 ### Added

--- a/src/lib/core/info-list-item/info-list-item.component.ts
+++ b/src/lib/core/info-list-item/info-list-item.component.ts
@@ -73,7 +73,7 @@ type DividerType = 'full' | 'partial' | undefined;
                 <div #right class="blui-info-list-item-right-content-wrapper">
                     <ng-content select="[blui-right-content]"></ng-content>
                 </div>
-                <mat-icon *ngIf="chevron && isEmpty(rightEl)" class="blui-chevron">chevron_right</mat-icon>
+                <mat-icon *ngIf="chevron" class="blui-chevron">chevron_right</mat-icon>
             </div>
         </mat-list-item>
         <mat-divider


### PR DESCRIPTION
…sue is fixed

<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #418  .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
-  updated the code to allow chevron and right component use at same time in the <Info-list-item> 
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
-
![image](https://user-images.githubusercontent.com/13012853/224017387-f989ce21-eb69-4ea6-9283-205b74560e74.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn test

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


